### PR TITLE
Audit review 2

### DIFF
--- a/contracts/dao/extensions/zge001-proposal-voting.clar
+++ b/contracts/dao/extensions/zge001-proposal-voting.clar
@@ -104,7 +104,7 @@
 		)
 		(try! (is-governance-token governance-token))
 		(asserts! (>= block-height (get start-block-height proposal-data)) err-proposal-inactive)
-		(asserts! (< block-height (get end-block-height proposal-data)) err-proposal-inactive)
+		(asserts! (<= block-height (get end-block-height proposal-data)) err-proposal-inactive)
 		(map-set member-total-votes {proposal: proposal, voter: tx-sender, governance-token: token-principal}
 			(+ (get-current-total-votes proposal tx-sender token-principal) amount)
 		)
@@ -128,7 +128,7 @@
 			(passed (> (get votes-for proposal-data) (get votes-against proposal-data)))
 		)
 		(asserts! (not (get concluded proposal-data)) err-proposal-already-concluded)
-		(asserts! (>= block-height (get end-block-height proposal-data)) err-end-block-height-not-reached)
+		(asserts! (> block-height (get end-block-height proposal-data)) err-end-block-height-not-reached)
 		(map-set proposals (contract-of proposal) (merge proposal-data {concluded: true, passed: passed}))
 		(print {event: "conclude", proposal: proposal, passed: passed})
 		(and passed (try! (contract-call? .executor-dao execute proposal tx-sender)))

--- a/contracts/loan/payment-fixed.clar
+++ b/contracts/loan/payment-fixed.clar
@@ -123,7 +123,7 @@
     ;; P * r * t => Amount * perc_rate * blocks
     ;; amount * delta * (APR / blocks_per_year)
     (payment (get-payment token-id amount (get payment-period loan) apr height (get next-payment loan) caller))
-    (early-payment (+ payment (get-prc payment (var-get early-repayment-fee))))
+    (early-payment (+ payment (get-prc payment (get-early-repayment-fee token-id))))
     (xbtc-staker-portion (get-prc early-payment (get cover-fee pool)))
     (xbtc-delegate-portion (get-prc early-payment (get delegate-fee pool)))
     (xbtc-lp-portion (- early-payment xbtc-staker-portion xbtc-delegate-portion))
@@ -171,7 +171,7 @@
   (let (
     (payment (/ (/ (* amount payment-period apr PRECISION) BLOCKS_PER_YEAR) PRECISION DEN)))
     (if (and (is-paying-late-fees caller) (> height next-payment))
-      (+ payment (/ (* payment (var-get late-fee)) DEN))
+      (+ payment (/ (* payment (get-late-fee token-id)) DEN))
       payment)))
 
 (define-read-only (get-payment-at-height (loan-id uint) (height uint) (caller principal))
@@ -179,7 +179,7 @@
     (loan (contract-call? .loan-v1-0 get-loan-read loan-id))
     (token-id (contract-call? .pool-v1-0 get-loan-pool-id-read loan-id))
     (pool (contract-call? .pool-v1-0 get-pool-read token-id))
-    (payment (get-payment (get loan-amount loan) (get payment-period loan) (get apr loan) height (get next-payment loan) caller)))
+    (payment (get-payment token-id (get loan-amount loan) (get payment-period loan) (get apr loan) height (get next-payment loan) caller)))
     payment))
 
 (define-read-only (get-current-loan-payment (loan-id uint) (caller principal))
@@ -187,7 +187,7 @@
     (loan (contract-call? .loan-v1-0 get-loan-read loan-id))
     (token-id (contract-call? .pool-v1-0 get-loan-pool-id-read loan-id))
     (pool (contract-call? .pool-v1-0 get-pool-read token-id))
-    (payment (get-payment (get loan-amount loan) (get payment-period loan) (get apr loan) burn-block-height (get next-payment loan) caller)))
+    (payment (get-payment token-id (get loan-amount loan) (get payment-period loan) (get apr loan) burn-block-height (get next-payment loan) caller)))
     payment))
 
 (define-read-only (get-early-repayment-amount (loan-id uint) (caller principal))
@@ -195,8 +195,8 @@
     (loan (contract-call? .loan-v1-0 get-loan-read loan-id))
     (token-id (contract-call? .pool-v1-0 get-loan-pool-id-read loan-id))
     (pool (contract-call? .pool-v1-0 get-pool-read token-id))
-    (payment (get-payment (get loan-amount loan) (get payment-period loan) (get apr loan) burn-block-height (get next-payment loan) caller))
-    (early-repayment (get-prc payment (var-get early-repayment-fee))))
+    (payment (get-payment token-id (get loan-amount loan) (get payment-period loan) (get apr loan) burn-block-height (get next-payment loan) caller))
+    (early-repayment (get-prc payment (get-early-repayment-fee token-id))))
     (+ payment early-repayment (get loan-amount loan))))
 
 (define-read-only (get-prc (amount uint) (bp uint))
@@ -290,28 +290,28 @@
 ;; @desc set late fee
 ;; @param fee: new late fee in BP
 ;; @returns (response true uint)
-(define-public (set-late-fee (fee uint))
+(define-public (set-late-fee (token-id uint) (fee uint))
   (begin
     (asserts! (is-contract-owner tx-sender) ERR_UNAUTHORIZED)
     (asserts! (not (contract-call? .pool-v1-0 is-ready token-id)) ERR_PARAM_LOCKED)
     (print { type: "set-late-fee-payment-fixed", payload: { token-id: token-id, fee: fee } })
-    (ok (var-set late-fee fee))))
+    (ok (map-set late-fee token-id fee))))
 
 (define-read-only (get-late-fee (token-id uint))
   (default-to u10 (map-get? late-fee token-id)))
 
 ;; -- token-id -> early-repayment-fee
-(define-data-var early-repayment-fee uint u10) ;; fee in Basis Points
+(define-map early-repayment-fee uint uint)
 
 ;; @desc set early repayment fee
 ;; @param fee: new early repayment fee in BP
 ;; @returns (response true uint)
-(define-public (set-early-repayment-fee (fee uint))
+(define-public (set-early-repayment-fee (token-id uint) (fee uint))
   (begin
     (asserts! (is-contract-owner tx-sender) ERR_UNAUTHORIZED)
     (asserts! (not (contract-call? .pool-v1-0 is-ready token-id)) ERR_PARAM_LOCKED)
     (print { type: "set-early-repayment-fee-payment-fixed", payload: { token-id: token-id, early-repayment-fee: fee } })
-    (ok (var-set early-repayment-fee fee))))
+    (ok (map-set early-repayment-fee token-id fee))))
 
 (define-read-only (get-early-repayment-fee (token-id uint))
   (default-to u10 (map-get? early-repayment-fee token-id)))

--- a/contracts/loan/payment-fixed.clar
+++ b/contracts/loan/payment-fixed.clar
@@ -281,7 +281,7 @@
 
     (if (get available cover-pool) (try! (contract-call? cp-token add-rewards token-id cover-portion)) u0)
 
-    (try! (contract-call? .read-data add-cover-pool-zest-rewards-earned token-id (+ cover-portion)))
+    (try! (contract-call? .read-data add-cover-pool-zest-rewards-earned token-id cover-portion))
     (ok true)))
 
 ;; -- token-id -> late-fee


### PR DESCRIPTION
Issue A: added access-control so only pool-delegate can call `pool-v1-0::unwind`
Issue B: maps `late-fee` and `early-repayment-fee` have getters and setters in `payment.clar`

Suggestion 4: There are 2 transfers to recipient in case of underflow between `coll-amount` and `amount`. Only one branch is executed.

Suggestion 5: Operators have been changed in zge001-proposal::vote

Suggestion 1: In payment-fixed::distribute-zest, zest rewards are minted for the pool-delegate. In payment-fixed::distribute-zest, the addition operation is removed.
